### PR TITLE
Fix sparse vectors eadd on CPU

### DIFF
--- a/src/cpu/cpu_v_eadd.hpp
+++ b/src/cpu/cpu_v_eadd.hpp
@@ -86,6 +86,9 @@ namespace spla {
             const CpuCooVec<T>* p_v      = v->template get<CpuCooVec<T>>();
             const auto&         function = op->function;
 
+            const T u_fill_value = u->get_fill_value();
+            const T v_fill_value = v->get_fill_value();
+
             assert(p_r->Ax.empty());
 
             const auto u_count = p_u->values;
@@ -96,11 +99,11 @@ namespace spla {
             while (u_iter < u_count && v_iter < v_count) {
                 if (p_u->Ai[u_iter] < p_v->Ai[v_iter]) {
                     p_r->Ai.push_back(p_u->Ai[u_iter]);
-                    p_r->Ax.push_back(p_u->Ax[u_iter]);
+                    p_r->Ax.push_back(function(p_u->Ax[u_iter], v_fill_value));
                     u_iter += 1;
                 } else if (p_v->Ai[v_iter] < p_u->Ai[u_iter]) {
                     p_r->Ai.push_back(p_v->Ai[v_iter]);
-                    p_r->Ax.push_back(p_v->Ax[v_iter]);
+                    p_r->Ax.push_back(function(u_fill_value, p_v->Ax[v_iter]));
                     v_iter += 1;
                 } else {
                     p_r->Ai.push_back(p_u->Ai[u_iter]);
@@ -112,13 +115,13 @@ namespace spla {
             }
             while (u_iter < u_count) {
                 p_r->Ai.push_back(p_u->Ai[u_iter]);
-                p_r->Ax.push_back(p_u->Ax[u_iter]);
+                p_r->Ax.push_back(function(p_u->Ax[u_iter], v_fill_value));
                 u_iter += 1;
                 p_r->values += 1;
             }
             while (v_iter < v_count) {
                 p_r->Ai.push_back(p_v->Ai[v_iter]);
-                p_r->Ax.push_back(p_v->Ax[v_iter]);
+                p_r->Ax.push_back(function(u_fill_value, p_v->Ax[v_iter]));
                 v_iter += 1;
                 p_r->values += 1;
             }


### PR DESCRIPTION
## Short description

Replace absent vectors' elements with corresponding _fill_value_ in sparse to sparse vectors ewiseadd operation on CPU

## List of changes

Fix implementation of `src/cpu/cpu_v_eadd.hpp:spla::Algo_v_eadd_cpu::execute_spNsp`

## Type of changes

- [x] *bug-fix* (change which fixes #229 )
- [ ] *new-feature* (change which proposes new feature or functionality)
- [ ] *breaking-change* (change which brakes compatibility of api or etc.)

## Testing strategy

Run _vector_ tests without OpenCL accelerators:

* Replace `SPLA_GTEST_MAIN_WITH_FINALIZE_PLATFORM(0)` in _tests/test_vector.cpp:500_
with `SPLA_GTEST_MAIN_WITH_FINALIZE_NO_ACC()`
* Rebuild project
* Run tests

Now test `vector.eadd_sub_pow2` works fine on CPU
